### PR TITLE
Accessibility fixes

### DIFF
--- a/themes/guides/i18n/en.toml
+++ b/themes/guides/i18n/en.toml
@@ -47,3 +47,6 @@ other = "{{ .Count }} words"
 
 [pageTitle]
 other = "{{ .Name }} page"
+
+[translations]
+other = "Languages"

--- a/themes/guides/i18n/es.toml
+++ b/themes/guides/i18n/es.toml
@@ -39,3 +39,6 @@ other = "A continuación encontrará las páginas asociadas a “{{ .Title }}”
 
 [pageTitle]
 other = "{{ .Name }} pagina"
+
+[translations]
+other = "Traducciones"

--- a/themes/guides/i18n/fr.toml
+++ b/themes/guides/i18n/fr.toml
@@ -47,3 +47,6 @@ other = "{{ .Count }} mots"
 
 [pageTitle]
 other = "{{ .Name }} page"
+
+[translations]
+other = "Traductions"

--- a/themes/guides/layouts/_default/baseof.html
+++ b/themes/guides/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="{{ .Lang }}">
     {{- partialCached "head.html" . -}}
 
     <body>

--- a/themes/guides/layouts/partials/head.html
+++ b/themes/guides/layouts/partials/head.html
@@ -3,7 +3,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{ .Site.Title }}</title>
-  {{ $script := resources.Get "/uswds/dist/js/uswds-init.min.js" }}
+  {{ $script := resources.Get "/uswds/dist/js/uswds-init.min.js" | resources.Fingerprint}}
   <script src="{{ $script.Permalink }}"></script>
   {{ $style := resources.Get "/uswds/dist/css/uswds.min.css" | resources.Fingerprint }}
   <link rel="stylesheet" href="{{ $style.Permalink }}">

--- a/themes/guides/layouts/partials/header.html
+++ b/themes/guides/layouts/partials/header.html
@@ -3,7 +3,7 @@
   <div class="usa-nav-container">
     <div class="usa-navbar">
       <div class="usa-logo" id="-logo">
-        <em class="usa-logo__text"><a href="/" title="Home">Logo</a></em>
+        <em class="usa-logo__text"><a href="{{ .Site.BaseURL }}" title="Home">Logo</a></em>
       </div>
       <button type="button" class="usa-menu-btn">Menu</button>
     </div>


### PR DESCRIPTION
Fixed the following pa11y-ci issues on the homepage:

```
Errors in http://localhost:1313/:

 • The html element should have a lang or xml:lang attribute which describes the language of the
   document.

   (html)

   <html class=""><head> <meta name="generator" ...</html>

 • Heading tag found with no content. Text that is not intended as a heading should not be marked up
   with heading tags.

   (html > body > header > div > h4)

   <h4></h4>
```
