### PR TITLE
More a11y checks

### DIFF
--- a/archetypes/section-bundle/_index.md
+++ b/archetypes/section-bundle/_index.md
@@ -1,7 +1,9 @@
 ---
 title: "{{ replace .Name "-" " " | title }}"
 type: landing
+hero: true
 icon: "images/product.svg"
+hero: true
 ---
 
 Landing page for {{ .Section }}

--- a/config.yml
+++ b/config.yml
@@ -13,5 +13,9 @@ languages:
     languageName: Français
     title: Guides et méthodes 18F
     weight: 1
+sitemap:
+  changefreq: monthly
+  filename: sitemap.xml
+  priority: 0.4
 Params:
   shortTitle: Guides

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -3,6 +3,7 @@ title: "Guides"
 description: "Principles and standards that shape our work"
 theme_version: '2.8.2'
 type: list
+hero: true
 cascade:
   featured_image: ''
 abstract: "18F’s work with other agencies is built on user-centered development, testing to validate hypotheses, shipping often, and deploying products in the open. Below are the technical guides that bring those principles into our day-to-day work."

--- a/content/en/about.md
+++ b/content/en/about.md
@@ -1,11 +1,9 @@
 ---
 title: "About"
-description: "A few years ago, while visiting or, rather, rummaging about Notre-Dame, the author of this book found, in an obscure nook of one of the towers, the following word, engraved by hand upon the wall: —ANANKE."
 featured_image: '/images/Victor_Hugo-Hunchback.jpg'
 menu:
   main:
     weight: 1
 ---
-{{< figure src="/images/Victor_Hugo-Hunchback.jpg" title="Illustration from Victor Hugo et son temps (1881)" >}}
 
-_The Hunchback of Notre-Dame_ (French: _Notre-Dame de Paris_) is a French Romantic/Gothic novel by Victor Hugo, published in 1831. The original French title refers to Notre Dame Cathedral, on which the story is centered. English translator Frederic Shoberl named the novel The Hunchback of Notre Dame in 1833 because at the time, Gothic novels were more popular than Romance novels in England. The story is set in Paris, France in the Late Middle Ages, during the reign of Louis XI.
+Lorem, ipsum dolor sit amet consectetur adipisicing elit. Voluptatem, neque praesentium, voluptates soluta provident consectetur delectus, sapiente aut eligendi et beatae cupiditate aliquid saepe vitae vero? Adipisci ducimus quasi ipsam.

--- a/content/en/section1/_index.md
+++ b/content/en/section1/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Section1"
 type: landing
+hero: true
 icon: "images/accessibility.svg"
 ---
 

--- a/content/en/section2/_index.md
+++ b/content/en/section2/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Section2"
 type: landing
+hero: true
 icon: "images/agile.svg"
 ---
 

--- a/content/en/section3/_index.md
+++ b/content/en/section3/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Section3"
 type: landing
+hero: true
 icon: "images/content.svg"
 ---
 

--- a/content/en/section4/_index.md
+++ b/content/en/section4/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Section4"
 type: landing
+hero: true
 icon: "images/derisking.svg"
 ---
 

--- a/content/en/section5/_index.md
+++ b/content/en/section5/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Section5"
 type: landing
+hero: true
 icon: "images/design-methods.svg"
 ---
 

--- a/content/en/section5/page-with-images.md
+++ b/content/en/section5/page-with-images.md
@@ -9,7 +9,7 @@ title: "Page with images"
 
 ## Figure shortcode
 
-{{< figure class="width-tablet" src="../assets/images/built-to-grow--alt.jpg" title="Steve Francia" >}}
+{{< figure class="width-tablet" src="../assets/images/built-to-grow--alt.jpg" title="Built to grow" alt="Built to grow" >}}
 
 ## Media card shortcode
 

--- a/content/en/section6/_index.md
+++ b/content/en/section6/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Section6"
 type: landing
+hero: true
 icon: "images/user-interviews-love--c.svg"
 ---
 

--- a/content/en/section6/page-with-images.md
+++ b/content/en/section6/page-with-images.md
@@ -8,7 +8,7 @@ title: "Page with images"
 
 ## Figure shortcode
 
-{{< figure class="width-tablet" src="../assets/images/built-to-grow--alt.jpg" title="Steve Francia" >}}
+{{< figure class="width-tablet" src="../assets/images/built-to-grow--alt.jpg" title="Built to grow" alt="Built to grow" >}}
 
 ## Media card shortcode
 

--- a/themes/guides/layouts/_default/single.html
+++ b/themes/guides/layouts/_default/single.html
@@ -7,7 +7,7 @@
         {{ .Title }}
       </h1>
     </header>
-    <div class="nested-copy-line-height lh-copy f4 nested-links {{ $.Param " text_color" | default "mid-gray" }}">
+    <div class="usa-prose">
       {{ .Content }}
     </div>
   </article>

--- a/themes/guides/layouts/partials/hero.html
+++ b/themes/guides/layouts/partials/hero.html
@@ -1,3 +1,4 @@
+{{ if .Params.hero }}
 <section>
   <div class="padding-y-2 bg-primary-darker">
     <div class="grid-container">
@@ -12,3 +13,4 @@
     </div>
   </div>
 </section>
+{{ end }}


### PR DESCRIPTION
Fix the following missing alt text warnings from pa11y-ci:

**Errors in http://localhost:1313/about/:**

 • Img element missing an alt attribute. Use the alt attribute to specify a short text alternative.
   (#content > div > article > div > figure > img)

   `<img src="/images/Victor_Hugo-Hunchback.jpg">`

**Errors in http://localhost:1313/section5/page-with-images/:**

 • Img element missing an alt attribute. Use the alt attribute to specify a short text alternative.
   (#content > div:nth-child(2) > article > div > figure > img)

   `<img src="../assets/images/built-to-grow--alt.jpg">`

**Errors in http://localhost:1313/section6/page-with-images/:**
 • Img element missing an alt attribute. Use the alt attribute to specify a short text alternative.

   (#content > div > article > div > figure > img)

  ` <img src="../assets/images/built-to-grow--alt.jpg">`
