### PR TITLE
New multilanguage adr.

### DIFF
--- a/doc/adr/0003-show-multilanguage-support-of-english-and-spanish.md
+++ b/doc/adr/0003-show-multilanguage-support-of-english-and-spanish.md
@@ -16,5 +16,12 @@ Enable and configure Hugo's [multilingual mode](https://gohugo.io/content-manage
 
 ## Consequences
 
-URL handling of translated pages is straightforward. It becomes easy to manage string translations in the i18n toml files. **Risks:**
-Content translation is not automated, so content managers will have to seek translators and save translations under `content/<TRANSLATION>/` directory. To avoid duplicating the number of assets (such as images), content managers should point to the default language directory for assets. Note: Hugo thought of this and resolved it using [Page bundles](To avoid the burden of having to duplicate files, each Page Bundle inherits the resources of its linked translated pages’ bundles except for the content files (Markdown files, HTML files etc…). Therefore, from within a template, the page will have access to the files from all linked pages’ bundles.).
+URL handling of translated pages is straightforward. It becomes easy to manage string translations in the i18n toml files.
+
+### Risks
+
+1. Content translation is not automated, so content managers will have to seek translators and save translations under `content/<TRANSLATION>/` directory. The future CMS will have to account for this.
+2. Duplicate the number of assets (such as images). Content managers should point to the default language directory for assets.
+
+  **Note:** Hugo thought of this and resolved it using [Page bundles](https://gohugo.io/content-management/multilingual/#page-bundles).
+  > To avoid the burden of having to duplicate files, each Page Bundle inherits the resources of its linked translated pages’ bundles except for the content files (Markdown files, HTML files etc…). Therefore, from within a template, the page will have access to the files from all linked pages’ bundles.).

--- a/doc/adr/0003-show-multilanguage-support-of-english-and-spanish.md
+++ b/doc/adr/0003-show-multilanguage-support-of-english-and-spanish.md
@@ -1,0 +1,20 @@
+# 3. Show multilanguage support of English and Spanish.
+
+Date: 2022-11-11
+
+## Status
+
+Proposed
+
+## Context
+
+One of the TTS Engineering Guild's requirements for an SSG is "doesn’t make multilingual support hard". 18F Engineering chapter's Engineering Chapter's requirement is "Multilingual/i18n support."
+
+## Decision
+
+Enable and configure Hugo's [multilingual mode](https://gohugo.io/content-management/multilingual/#translation-of-strings). Use [USWDS pattern](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/jb-patterns-complete-a-profile/patterns/language-selector/two-languages/) "Select a language" for displaying language options. Configure default English (en) and Spanish (es).
+
+## Consequences
+
+URL handling of translated pages is straightforward. It becomes easy to manage string translations in the i18n toml files. **Risks:**
+Content translation is not automated, so content managers will have to seek translators and save translations under `content/<TRANSLATION>/` directory. To avoid duplicating the number of assets (such as images), content managers should point to the default language directory for assets. Note: Hugo thought of this and resolved it using [Page bundles](To avoid the burden of having to duplicate files, each Page Bundle inherits the resources of its linked translated pages’ bundles except for the content files (Markdown files, HTML files etc…). Therefore, from within a template, the page will have access to the files from all linked pages’ bundles.).


### PR DESCRIPTION
# 3. Show multilanguage support of English and Spanish.

Date: 2022-11-11

## Status

Proposed

## Context

One of the TTS Engineering Guild's requirements for an SSG is "doesn’t make multilingual support hard". 18F Engineering chapter's Engineering Chapter's requirement is "Multilingual/i18n support."

## Decision

Enable and configure Hugo's [multilingual mode](https://gohugo.io/content-management/multilingual/#translation-of-strings). Use [USWDS pattern](https://federalist-ead78f8d-8948-417c-a957-c21ec5617a57.app.cloud.gov/preview/uswds/uswds-site/jb-patterns-complete-a-profile/patterns/language-selector/two-languages/) "Select a language" for displaying language options. Configure default English (en) and Spanish (es).

## Consequences

URL handling of translated pages is straightforward. It becomes easy to manage string translations in the i18n toml files. 

### Risks

1. Content translation is not automated, so content managers will have to seek translators and save translations under `content/<TRANSLATION>/` directory. The future CMS will have to account for this.
2. Duplicate the number of assets (such as images). Content managers should point to the default language directory for assets.

  **Note:** Hugo thought of this and resolved it using [Page bundles](https://gohugo.io/content-management/multilingual/#page-bundles).
  > To avoid the burden of having to duplicate files, each Page Bundle inherits the resources of its linked translated pages’ bundles except for the content files (Markdown files, HTML files etc…). Therefore, from within a template, the page will have access to the files from all linked pages’ bundles.).
