### PR TITLE
Add summary-box of Hugo page variables.

### DIFF
--- a/themes/guides/i18n/en.toml
+++ b/themes/guides/i18n/en.toml
@@ -39,7 +39,7 @@ other = "Below you will find pages that utilize the taxonomy term “{{ .Title }
 
 [readingTime]
 one = "One minute read"
-other = "{{ .Count }} minutes read"
+other = " minutes read"
 
 [wordCount]
 one = "One word"

--- a/themes/guides/layouts/_default/single.html
+++ b/themes/guides/layouts/_default/single.html
@@ -10,6 +10,7 @@
     <div class="usa-prose">
       {{ .Content }}
     </div>
+    {{ partial "summary-box" .}}
   </article>
 </main>
 {{ end }}

--- a/themes/guides/layouts/partials/summary-box.html
+++ b/themes/guides/layouts/partials/summary-box.html
@@ -1,0 +1,21 @@
+<div class="usa-summary-box margin-top-6" role="region" aria-labelledby="summary-box-key-information">
+  <div class="usa-summary-box__body">
+    <h3 class="usa-summary-box__heading" id="summary-box-key-information">
+      Page information
+    </h3>
+    <div class="usa-summary-box__text">
+      <ul class="usa-list">
+        <li>Wordcount: {{ .WordCount }}</li>
+        <li>ReadingTime: {{ i18n "readingTime" .ReadingTime }}</li>
+        <li>Aliases: {{ .Aliases }}</li>
+        <li>BundleType: {{ .BundleType }}</li>
+        <li>Publish date: {{ .PublishDate | time.Format ":date_long" }}</li>
+        <li>Last modified: {{ .Lastmod | time.Format ":date_long" }}</li>
+        <li>Sort weight: {{ .Weight }}</li>
+        <li>Is translated: {{ .IsTranslated }}</li>
+        <li>Previous page: {{ with .PrevInSection }}{{ .Permalink }}{{ end }} </li>
+        <li>Next page: {{ with .NextInSection }}{{ .Permalink }}{{ end }} </li>
+      </ul>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
I might keep this as an open PR. 

Want to demonstrate the type of page info available to us which might be helpful in our future design.