### PR TITLE
Add a `fancy` sub-theme

### DIFF
--- a/archetypes/section-bundle/card-page.md
+++ b/archetypes/section-bundle/card-page.md
@@ -1,6 +1,6 @@
 ---
 title: "Card Page"
-type: card
+
 ---
 
 ## What

--- a/content/en/section1/subsectiona/card-page.md
+++ b/content/en/section1/subsectiona/card-page.md
@@ -1,6 +1,6 @@
 ---
 title: "Card Page"
-type: card
+
 ---
 
 Lorem ipsum dolor sit, amet consectetur adipisicing elit. Consequuntur ut dolor praesentium facere rerum aliquam minima rem eligendi aut fugit repellendus, illum tempore voluptate labore eum vel ullam nemo laboriosam!

--- a/content/en/section1/subsectionb/another-new-page.md
+++ b/content/en/section1/subsectionb/another-new-page.md
@@ -1,6 +1,6 @@
 ---
 title: "Another new page"
-type: card
+
 ---
 
 Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex alias, ipsum optio aperiam delectus aliquam nisi atque labore ipsa totam impedit illo, tempora, a natus dolorum expedita! Laudantium, necessitatibus non!

--- a/content/en/section1/subsectionb/card-page.md
+++ b/content/en/section1/subsectionb/card-page.md
@@ -1,6 +1,6 @@
 ---
 title: "Card Page"
-type: card
+
 ---
 
 ## What

--- a/content/en/section2/another-new-page.md
+++ b/content/en/section2/another-new-page.md
@@ -1,6 +1,6 @@
 ---
 title: "Another new page"
-type: card
+
 ---
 
 Lorem ipsum dolor sit amet consectetur adipisicing elit. Ex alias, ipsum optio aperiam delectus aliquam nisi atque labore ipsa totam impedit illo, tempora, a natus dolorum expedita! Laudantium, necessitatibus non!

--- a/content/en/section2/card-page.md
+++ b/content/en/section2/card-page.md
@@ -1,6 +1,6 @@
 ---
 title: "Card Page"
-type: card
+
 ---
 
 ## What

--- a/content/en/section4/card-page.md
+++ b/content/en/section4/card-page.md
@@ -1,6 +1,6 @@
 ---
 title: "Card Page"
-type: card
+
 ---
 
 ## What

--- a/content/en/section5/create/breadcrumb-page.md
+++ b/content/en/section5/create/breadcrumb-page.md
@@ -2,6 +2,7 @@
 title: "Breadcrumb page"
 page: top
 breadcrumb: true
+page_color: bg-secondary-dark
 ---
 
 _By definition, this agile guide is a work in progress. We welcome community participation._

--- a/content/en/section5/create/card-page.md
+++ b/content/en/section5/create/card-page.md
@@ -1,12 +1,7 @@
 ---
 title: "Card Page"
-type: card
+breadcrumb: true
+what: "An evaluation method in which people work through a set of representative tasks and ask questions about the task as they go."
+why: "To get quick and early feedback on whether a design solution is easy for a new or infrequent user to learn, and why it is or isn’t easy. This method is useful for catching big issues at any stage in the design process when you don’t have access to real users, but it is not a substitute for user evaluation.
+"
 ---
-
-## What
-
-An evaluation method in which people work through a set of representative tasks and ask questions about the task as they go.
-
-## Why
-
-To get quick and early feedback on whether a design solution is easy for a new or infrequent user to learn, and why it is or isn’t easy. This method is useful for catching big issues at any stage in the design process when you don’t have access to real users, but it is not a substitute for user evaluation.

--- a/content/en/section5/create/cognitive-walkthrough.md
+++ b/content/en/section5/create/cognitive-walkthrough.md
@@ -1,0 +1,32 @@
+---
+title: Cognitive walkthrough
+breadcrumb: true
+redirect_from:
+  - /cognitive-walkthrough/
+description: An evaluation method in which people work through a set of representative tasks and ask questions about the task as they go.
+category: Create
+what: An evaluation method in which people work through a set of representative tasks and ask questions about the task as they go.
+why: To get quick and early feedback on whether a design solution is easy for a new or infrequent user to learn, and why it is or isn’t easy. This method is useful for catching big issues at any stage in the design process when you don't have access to real users, but it is not a substitute for user evaluation.
+resources:
+  0: "This section is an array (bulleted list) of rich text."
+  1: "Each item can include [links](http://google.com). The content is run through the `markdownify` filter."
+  2: "It can also include plain text or a combination of both."
+  3: "This section is hidden from the print card."
+considerations: "This section supports multiple paragraphs of text.
+\
+No HTML allowed! This content if also run through the `markdownify` filter.
+\
+This section is also hidden from the print card."
+timeRequired: 30 minutes to one hour per person
+tags: [UX, methods]
+---
+
+## How to do it
+
+1. Identify specific traits for new or infrequent users of a design solution.
+1. Develop a set of representative tasks that emphasize new use or infrequent use.
+1. Designate a member of the design team to play the role of a user. That person will use the traits you've identified to participate in a moderated usability testing session. (The traits can overlap.)
+1. Ask the user to accomplish their goal using a printed or interactive design. As they go, ask what they would attempt to do next or how they would learn.
+  1. Don't lead the user through the task, but encourage them to stay focused on what they're trying to accomplish.
+  1. Pay attention to expected outcomes and how quickly/easily participants are able to pick up a task.
+1. Analyze the walkthrough results to highlight where the user struggled and what needs improvement.

--- a/content/en/section5/create/page-with-images.md
+++ b/content/en/section5/create/page-with-images.md
@@ -20,4 +20,3 @@ title: "Page with images"
   size="width-mobile"
   link_text="Call to action"
 >}}
-

--- a/content/en/section5/pioneer/card-page.md
+++ b/content/en/section5/pioneer/card-page.md
@@ -1,6 +1,6 @@
 ---
 title: "Card Page"
-type: card
+
 ---
 
 ## What

--- a/content/en/section6/card-page.md
+++ b/content/en/section6/card-page.md
@@ -1,6 +1,6 @@
 ---
 title: "Card Page"
-type: card
+
 ---
 
 ## What

--- a/themes/guides/i18n/en.toml
+++ b/themes/guides/i18n/en.toml
@@ -83,3 +83,6 @@ other = "Return to top"
 
 [improvePage]
 other = "Improve this page"
+
+[404]
+other = "This is not the page you were looking for"

--- a/themes/guides/layouts/404.html
+++ b/themes/guides/layouts/404.html
@@ -1,8 +1,10 @@
 {{ define "header" }}{{ partial "header.html" . }}{{ end }}
 {{ define "main" }}
-<article class="center cf pv5 measure-wide-l">
-  <h1>
-    This is not the page you were looking for
-  </h1>
-</article>
+<main id="main-content" class="grid-container minh-mobile">
+  <article class="">
+    <h1>
+      {{ i18n "404" }}
+    </h1>
+  </article>
+</main>
 {{ end }}

--- a/themes/guides/layouts/partials/summary-box.html
+++ b/themes/guides/layouts/partials/summary-box.html
@@ -5,6 +5,7 @@
     </h3>
     <div class="usa-summary-box__text">
       <ul class="usa-list">
+        <li>Link title: {{ .LinkTitle }}</li>
         <li>Hero: {{ cond (ne .Params.hero nil) "on" "off" }}</li>
         <li>Breadcrumb: {{ cond (ne .Params.breadcrumb nil) "on" "off" }}</li>
         <li>Side navigation: {{ cond (ne .Params.sidenav nil) "on" "off" }}</li>

--- a/themes/guides/layouts/partials/summary-box.html
+++ b/themes/guides/layouts/partials/summary-box.html
@@ -17,13 +17,14 @@
         <li>Last modified: {{ .Lastmod | time.Format ":date_long" }}</li>
         <li>Sort weight: {{ .Weight }}</li>
         <li>Is translated: {{ .IsTranslated }}</li>
-        <li>Previous page: {{ with .PrevInSection }}{{ .Permalink }}{{ end }} </li>
-        <li>Next page: {{ with .NextInSection }}{{ .Permalink }}{{ end }} </li>
+        <li>Previous page: {{ with .PrevInSection }}<a href="{{ .Permalink }}">{{ .Title }}</a>{{ end }} </li>
+        <li>Next page: {{ with .NextInSection }} <a href="{{ .Permalink }}">{{ .Title }}</a>{{ end }} </li>
         <li>Tags:
           {{ range (.GetTerms "tags") }}
           <a href="{{ .Permalink }}">{{ .LinkTitle }}</a>
           {{ end }}
         </li>
+        <li>Summary: {{ .Summary }}</li>
       </ul>
     </div>
   </div>

--- a/themes/guides/layouts/section5/list.html
+++ b/themes/guides/layouts/section5/list.html
@@ -12,7 +12,7 @@
     <div class="grid-col grid-col-4">
       <h4>Content includes</h4>
       <ul class="usa-list--unstyled">
-        {{ range first 3 .Pages }}
+        {{ range .Pages }}
         <li class="padding-bottom-1">
           <a href="{{ .Permalink }}">{{ .Title }}</a>
         </li>

--- a/themes/guides/layouts/section5/single.html
+++ b/themes/guides/layouts/section5/single.html
@@ -1,19 +1,49 @@
 {{ define "header" }}{{ partial "header.html" . }}{{ end }}
 {{ define "main" }}
-<main aria-role="main" id="main-content" class="grid-container">
-  <div class="usa-alert usa-alert--warning">
-    <div class="usa-alert__body">
-      <h4 class="usa-alert__heading">This is a {{ .Section }} page</h4>
-      <p class="usa-alert__text">
-        Lorem ipsum dolor sit amet,
-        <a class="usa-link" href="{{ .RelPermalink }}">consectetur adipiscing</a>
-        elit, sed do eiusmod.
-      </p>
-    </div>
-  </div>
-  <div class="flex-l mt2 mw8 center">
-    <article class="usa-prose">
-      {{ .Content }}
+{{ $pageColor := cond ( ne .Params.page_color nil ) .Params.page_color "bg-primary-light" }}
+<main aria-role="main" id="main-content" class="padding-y-6 {{ $pageColor }}">
+  <div class=" grid-container">
+    <article class="grid-row grid-gap bg-white border radius-lg padding-2 tablet:padding-3">
+      <div class="tablet:grid-col">
+        <h1>{{ .Title }}</h1>
+        <h2>What</h2>
+        <p>{{ .Params.what }}</p>
+        <h2>Why</h2>
+        <p>{{ .Params.why }}</p>
+      </div>
+      <div class="tablet:grid-col">
+        {{ if gt .WordCount 1 }}
+        {{ .Content }}
+        {{ else }}
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Similique, nulla deserunt ratione quo sequi dolorem
+        aut repellendus, praesentium tempora ad sit voluptatum quas fuga. Quaerat aliquam mollitia incidunt? Laudantium,
+        provident!
+        {{ end }}
+        <h2>Additional Resources</h2>
+        <ul>
+          {{ with .Params.resources }}
+          {{ range . }}
+          <li>{{ . | markdownify }}</li>
+          {{ end }}
+          {{ else }}
+          <li>This section is an array (bulleted list) of rich text.</li>
+          <li>Each item can include [links](http://google.com). The content is run through the `markdownify` filter.
+          </li>
+          <li>It can also include plain text or a combination of both.</li>
+          <li>This section is hidden from the print card.</li>
+          {{ end }}
+        </ul>
+        <h2>Considerations for use in government</h2>
+        {{ with .Params.considerations }}
+        {{ . | markdownify }}
+        {{ else }}
+        <p>This section supports multiple paragraphs of text.</p>
+        <p>
+          No HTML allowed! This content if also run through the `markdownify` filter.
+        </p>
+        <p>This section is also hidden from the print card.</p>
+        {{ end }}
+      </div>
     </article>
   </div>
 </main>


### PR DESCRIPTION
**Fancy**, being a loose IA label. 

### The **fancy** sub-theme includes
* card-like style for single pages.
* background color option called `page_color`. Defaults to the USWDS `bg-primary-light` color.
* custom front matter fields. `resources` is an array of markdown text. `considerations` is paragraph text.
* HTML templates for the custom front matter fields. We need to apply special CSS classes around these areas to hide them in the print version. Which is probably why the original pages included HTML in Markdown. No more! Now we have a custom template.

### Other changes

- Removed `type: card` from content pages, since we didn't have this layout.
- Changed `type: landing` to `layout: landing`, allowing us to still sort by landing pages in the homepage nav and top drop down nav.
- Now when `type: fancy` is applied to a page, it will use one of the `fancy` templates (single.html and list.html)
- We can cascade `type: fancy` to all pages within a section by including it in the section _index.html front matter. See section5/_index.md.

